### PR TITLE
Point node-postgres at the timeout branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "bluebird": "~2.9.0",
     "lodash": "^3.10",
     "mocha": "^2.3.4",
-    "pg": "4.3.0",
+    "pg": "git://github.com/Shyp/node-postgres#timeout",
     "sails-postgresql": "git+https://github.com/Shyp/sails-postgresql.git#v1.0.0",
     "should": "^8.0",
     "waterline": "git+https://github.com/Shyp/waterline.git#v1.3.0"


### PR DESCRIPTION
This lets node-postgres bubble up an error when the connection pool is full
