### PR TITLE
Update Waterline to v3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "pg": "git://github.com/Shyp/node-postgres#timeout",
     "sails-postgresql": "git+https://github.com/Shyp/sails-postgresql.git#v1.2.0",
     "should": "8",
-    "waterline": "git+https://github.com/Shyp/waterline.git#v1.3.0"
+    "waterline": "git+https://github.com/Shyp/waterline.git#v3.1.0"
   },
   "devDependencies": {
     "jpath": "^0.0.20",

--- a/test/integration/runnerDispatcher.js
+++ b/test/integration/runnerDispatcher.js
@@ -20,7 +20,7 @@ var adapters = ['sails-postgresql'];
 // Core modules npm Dependencies path
 var coreModulesPaths = {
   "waterline":               ".dependencies.waterline",
-  "- anchor":                ".dependencies.waterline.dependencies.anchor",
+  "- lusitania":             ".dependencies.waterline.dependencies.lusitania",
   "- waterline-schema":      ".dependencies.waterline.dependencies.waterline-schema",
   "waterline-adapter-tests": "."
 };


### PR DESCRIPTION
This branch renames Anchor to Lusitania, constructs simpler error objects, and
doesn't attempt to write the primary key when calling `.save()` on a field.

Diff: https://github.com/shyp/waterline/compare/v1.3.0...v3.1.0
