### PR TITLE
Replace assert(!err) with assert.ifError(err)

### DIFF
--- a/features/autoIncrement/core/autoIncrement.test.js
+++ b/features/autoIncrement/core/autoIncrement.test.js
@@ -74,7 +74,7 @@ describe('autoIncrement attribute feature', function() {
 
       AutoIncModel.find({where : { type: testName }, sort : {name : 1}}, function(err, records) {
         if (err) return done(err);
-        assert(!err);
+        assert.ifError(err);
         assert.equal(records.length, 10, 'Expecting 10 records, but got '+records.length);
 
         assert(records[0].id);
@@ -106,7 +106,7 @@ describe('autoIncrement attribute feature', function() {
 
       AutoIncModel.find({where : { type: testName }, sort : {name : 1}}, function(err, records) {
         if (err) return done(err);
-        assert(!err);
+        assert.ifError(err);
         assert.equal(records.length, 5, 'Expecting 5 records, but got '+records.length);
 
         assert.equal(records[0].name, 'ai_0');
@@ -128,7 +128,7 @@ describe('autoIncrement attribute feature', function() {
 
           AutoIncModel.find({where : { type: testName }, sort : {name : 1}}, function(err, records) {
             if (err) return done(err);
-            assert(!err);
+            assert.ifError(err);
             assert.equal(records.length, 10, 'Expecting 10 records, but got '+records.length);
 
             assert.equal(records[0].name, 'ai_0');

--- a/features/unique/core/unique.test.js
+++ b/features/unique/core/unique.test.js
@@ -65,7 +65,7 @@ describe('unique attribute feature', function() {
       assert(err);
       assert(!records);
       UniqueModel.find({type: 'unique'}).exec(function(err, records) {
-        assert(!err);
+        assert.ifError(err);
         assert.equal(records.length, 3);
         done();
       });
@@ -77,7 +77,7 @@ describe('unique attribute feature', function() {
       assert(err);
       assert(!records);
       UniqueModel.findOne(id1).exec(function(err, record) {
-        assert(!err);
+        assert.ifError(err);
         assert.notEqual(record.email, email0);
         done();
       });

--- a/interfaces/associations/belongsTo/create.js
+++ b/interfaces/associations/belongsTo/create.js
@@ -26,7 +26,7 @@ describe('Association Interface', function() {
 
       it('should create a foreign key value when passed an association key', function(done) {
         Associations.Payment.create({ amount: 1, a_customer: customerId }).exec(function(err, payment) {
-          assert(!err);
+          assert.ifError(err);
           assert.equal(payment.a_customer.toString(), customerId.toString());
           done();
         });

--- a/interfaces/associations/belongsTo/dynamicFinder.js
+++ b/interfaces/associations/belongsTo/dynamicFinder.js
@@ -36,7 +36,7 @@ describe('Association Interface', function() {
       it('should return customer when the dynamic finder method is used for findOne', function(done) {
         Associations.Payment.findOneByA_customer(customerRecord.id)
         .exec(function(err, payment) {
-          assert(!err);
+          assert.ifError(err);
 
           assert(payment.a_customer);
           assert.equal(payment.a_customer.id, customerRecord.id);
@@ -49,7 +49,7 @@ describe('Association Interface', function() {
       it('should return customer when the dynamic finder method is used for find', function(done) {
         Associations.Payment.findByA_customer(customerRecord.id)
         .exec(function(err, payments) {
-          assert(!err);
+          assert.ifError(err);
 
           assert(payments[0].a_customer);
           assert.equal(payments[0].a_customer.id, customerRecord.id);

--- a/interfaces/associations/belongsTo/find.populate.js
+++ b/interfaces/associations/belongsTo/find.populate.js
@@ -78,7 +78,7 @@ describe('Association Interface', function() {
       it('should not return a customer object when the populate is not added', function(done) {
         Associations.Payment.find()
         .exec(function(err, payments) {
-          assert(!err);
+          assert.ifError(err);
 
           assert(!_.isPlainObject(payments[0].a_customer));
           assert(!_.isPlainObject(payments[1].a_customer));
@@ -91,7 +91,7 @@ describe('Association Interface', function() {
         Associations.Payment.find()
         .populate('a_customer')
         .exec(function(err, payments) {
-          assert(!err);
+          assert.ifError(err);
 
           var obj = payments[0].toJSON();
 

--- a/interfaces/associations/belongsTo/findOne.populate.js
+++ b/interfaces/associations/belongsTo/findOne.populate.js
@@ -37,7 +37,7 @@ describe('Association Interface', function() {
         Associations.Payment.findOne({ id: paymentRecord.id })
         .populate('a_customer')
         .exec(function(err, payment) {
-          assert(!err);
+          assert.ifError(err);
 
           assert(payment.a_customer);
           assert.equal(payment.a_customer.id, customerRecord.id);
@@ -50,7 +50,7 @@ describe('Association Interface', function() {
       it('should not return a customer object when the populate is not added', function(done) {
         Associations.Payment.findOne({ id: paymentRecord.id })
         .exec(function(err, payment) {
-          assert(!err);
+          assert.ifError(err);
 
           assert(!_.isPlainObject(payment.a_customer));
 
@@ -62,7 +62,7 @@ describe('Association Interface', function() {
         Associations.Payment.findOne({ id: paymentRecord.id })
         .populate('a_customer')
         .exec(function(err, payment) {
-          assert(!err);
+          assert.ifError(err);
 
           var obj = payment.toJSON();
 

--- a/interfaces/associations/belongsTo/multipleForeignKeys.js
+++ b/interfaces/associations/belongsTo/multipleForeignKeys.js
@@ -31,7 +31,7 @@ describe('Association Interface', function() {
 
       it('should create multiple foreign key values when passed association keys', function(done) {
         Associations.Payment_many.create({ amount: 1, customer: customer_1_id, patron: customer_2_id }).exec(function(err, payment) {
-          assert(!err);
+          assert.ifError(err);
           assert.equal(payment.customer.toString(), customer_1_id.toString());
           assert.equal(payment.patron.toString(), customer_2_id.toString());
           done();
@@ -41,12 +41,12 @@ describe('Association Interface', function() {
       it('should populate values only for specified keys', function(done) {
 
         Associations.Payment_many.create({ amount: 10, customer: customer_1_id, patron: customer_2_id }).exec(function(err) {
-          assert(!err);
+          assert.ifError(err);
 
           Associations.Payment_many.findOne({ amount: 10 })
           .populate('patron')
           .exec(function(err, payment) {
-            assert(!err);
+            assert.ifError(err);
 
             var obj = payment.toJSON();
 

--- a/interfaces/associations/find.associations.test.js
+++ b/interfaces/associations/find.associations.test.js
@@ -54,7 +54,7 @@ describe('Association Interface', function() {
       .populate('payments', { sort: { amount: 1 }})
       .sort('id asc')
       .exec(function(err, customers) {
-        assert(!err);
+        assert.ifError(err);
         assert(Array.isArray(customers));
         assert.strictEqual(customers.length, 2);
 

--- a/interfaces/associations/hasMany/add.js
+++ b/interfaces/associations/hasMany/add.js
@@ -30,13 +30,13 @@ describe('Association Interface', function() {
         it('should create a new payment association', function(done) {
           customer.payments.add({ amount: 1337 });
           customer.save(function(err) {
-            assert(!err);
+            assert.ifError(err);
 
             // Look up the customer again to be sure the payment was added
             Associations.Customer.findOne(customer.id)
             .populate('payments')
             .exec(function(err, model) {
-              assert(!err);
+              assert.ifError(err);
 
               assert.strictEqual(model.payments.length, 2);
               assert.strictEqual(model.payments[1].amount, 1337);
@@ -81,13 +81,13 @@ describe('Association Interface', function() {
         it('should link the payment to another association', function(done) {
           customer.payments.add(payment.id);
           customer.save(function(err) {
-            assert(!err);
+            assert.ifError(err);
 
             // Look up the customer again to be sure the payment was added
             Associations.Customer.findOne(customer.id)
             .populate('payments')
             .exec(function(err, data) {
-              assert(!err);
+              assert.ifError(err);
 
               assert.strictEqual(data.payments.length, 1);
               assert.strictEqual(data.payments[0].amount, 1);

--- a/interfaces/associations/hasMany/create.nested.js
+++ b/interfaces/associations/hasMany/create.nested.js
@@ -67,13 +67,13 @@ describe('Association Interface', function() {
             };
 
             Associations.Customer.create(data).exec(function(err, values) {
-              assert(!err);
+              assert.ifError(err);
 
               // Look up the customer again to be sure the payments were added
               Associations.Customer.findOne(values.id)
               .populate('payments', { sort: 'amount ASC' })
               .exec(function(err, model) {
-                assert(!err);
+                assert.ifError(err);
                 assert.strictEqual(model.payments.length, 2);
                 assert.strictEqual(model.payments[1].amount, 2);
                 done();

--- a/interfaces/associations/hasMany/find.populate.js
+++ b/interfaces/associations/hasMany/find.populate.js
@@ -143,7 +143,7 @@ describe('Association Interface', function() {
       it('should add a flag to not serialize association object when the populate is not added', function(done) {
         Associations.Customer.find({ name: 'hasMany find pop' })
         .exec(function(err, customers) {
-          assert(!err);
+          assert.ifError(err);
 
           var obj = customers[0].toJSON();
           assert(!obj.payments);
@@ -156,7 +156,7 @@ describe('Association Interface', function() {
         Associations.Customer.find({ name: 'hasMany find pop' })
         .populate('payments')
         .exec(function(err, customers) {
-          assert(!err);
+          assert.ifError(err);
 
           var obj = customers[0].toJSON();
 

--- a/interfaces/associations/hasMany/find.populate.where.js
+++ b/interfaces/associations/hasMany/find.populate.where.js
@@ -84,7 +84,7 @@ describe('Association Interface', function() {
         .populate('payments', { skip: 1, limit: 2, sort: { amount: 1 } })
         .sort('capital asc')
         .exec(function(err, customers) {
-          assert(!err);
+          assert.ifError(err);
 
           assert(Array.isArray(customers));
           assert.strictEqual(customers.length, 2);
@@ -122,7 +122,7 @@ describe('Association Interface', function() {
           .populate('payments', {where : { id: payment.id }, sort : {amount : 1}})
           .sort('capital asc')
           .exec(function(err, customers) {
-            assert(!err);
+            assert.ifError(err);
 
             assert(Array.isArray(customers));
             assert.strictEqual(customers.length, 2);

--- a/interfaces/associations/hasMany/findOne.populate.js
+++ b/interfaces/associations/hasMany/findOne.populate.js
@@ -40,7 +40,7 @@ describe('Association Interface', function() {
        Associations. Customer.findOne({ id: customerRecord.id })
         .populate('payments')
         .exec(function(err, customer) {
-          assert(!err);
+          assert.ifError(err);
 
           assert(Array.isArray(customer.payments));
           assert.strictEqual(customer.payments.length, 4);
@@ -51,7 +51,7 @@ describe('Association Interface', function() {
       it('should add a flag to not serialize association object when the populate is not added', function(done) {
         Associations.Customer.findOne({ id: customerRecord.id })
         .exec(function(err, customer) {
-          assert(!err);
+          assert.ifError(err);
 
           var obj = customer.toJSON();
           assert(!obj.payments);
@@ -64,7 +64,7 @@ describe('Association Interface', function() {
         Associations.Customer.findOne({ id: customerRecord.id })
         .populate('payments')
         .exec(function(err, customer) {
-          assert(!err);
+          assert.ifError(err);
 
           var obj = customer.toJSON();
 

--- a/interfaces/associations/hasMany/multipleForeignKeys.js
+++ b/interfaces/associations/hasMany/multipleForeignKeys.js
@@ -31,14 +31,14 @@ describe('Association Interface', function() {
           customer.payments.add({ amount: 1337 });
           customer.transactions.add({ amount: 100 });
           customer.save(function(err) {
-            assert(!err);
+            assert.ifError(err);
 
             // Look up the customer again to be sure the payment was added
             Associations.Customer_many.findOne(customer.id)
             .populate('payments')
             .populate('transactions')
             .exec(function(err, customer) {
-              assert(!err);
+              assert.ifError(err);
 
               assert.strictEqual(customer.payments.length, 2);
               assert.strictEqual(customer.payments[1].amount, 1337);
@@ -86,13 +86,13 @@ describe('Association Interface', function() {
         it('should link the payment to another association', function(done) {
           customer.payments.add(payment.id);
           customer.save(function(err) {
-            assert(!err);
+            assert.ifError(err);
 
             // Look up the customer again to be sure the payment was added
             Associations.Customer_many.findOne(customer.id)
             .populate('payments')
             .exec(function(err, data) {
-              assert(!err);
+              assert.ifError(err);
 
               assert.strictEqual(data.payments.length, 1);
               assert.strictEqual(data.payments[0].amount, 1);

--- a/interfaces/associations/hasMany/remove.js
+++ b/interfaces/associations/hasMany/remove.js
@@ -38,13 +38,13 @@ describe('Association Interface', function() {
         it('should remove the customer_id foreign key from the payment', function(done) {
           customerRecord.payments.remove(paymentRecord.id);
           customerRecord.save(function(err) {
-            assert(!err);
+            assert.ifError(err);
 
             // Look up the customer again to be sure the payment was added
             Associations.Customer.findOne(customerRecord.id)
             .populate('payments')
             .exec(function(err, data) {
-              assert(!err);
+              assert.ifError(err);
 
               assert.strictEqual(data.payments.length, 0);
               done();

--- a/interfaces/associations/hasMany/update.nested.js
+++ b/interfaces/associations/hasMany/update.nested.js
@@ -44,13 +44,13 @@ describe('Association Interface', function() {
             };
 
             Associations.Customer.update({ id: Customer.id }, data).exec(function(err, values) {
-              assert(!err);
+              assert.ifError(err);
 
               // Look up the customer again to be sure the payments were added
               Associations.Customer.findOne(values[0].id)
               .populate('payments')
               .exec(function(err, model) {
-                assert(!err);
+                assert.ifError(err);
                 assert.equal(model.name, '1:m update nested - updated');
                 assert.strictEqual(model.payments.length, 1);
                 assert.strictEqual(model.payments[0].amount, 1);
@@ -105,13 +105,13 @@ describe('Association Interface', function() {
             };
 
             Associations.Customer.update({ id: Customer.id }, data).exec(function(err, values) {
-              assert(!err);
+              assert.ifError(err);
 
               // Look up the customer again to be sure the payments were added
               Associations.Customer.findOne(values[0].id)
               .populate('payments', { sort: 'amount ASC' })
               .exec(function(err, model) {
-                assert(!err);
+                assert.ifError(err);
                 assert.equal(model.name, '1:m update nested - updated');
                 assert.strictEqual(model.payments.length, 3);
                 assert.strictEqual(model.payments[0].amount, 3);
@@ -178,7 +178,7 @@ describe('Association Interface', function() {
               Associations.Customer.findOne(values[0].id)
               .populate('payments',{sort:{amount : 1}})
               .exec(function(err, model) {
-                assert(!err);
+                assert.ifError(err);
                 assert.equal(model.name, '1:m update nested - updated');
                 assert.strictEqual(model.payments.length, 2);
 

--- a/interfaces/associations/oneToOne/find.populate.js
+++ b/interfaces/associations/oneToOne/find.populate.js
@@ -55,7 +55,7 @@ describe('Association Interface', function() {
         .sort('level asc')
         .populate('user')
         .exec(function(err, profiles) {
-          assert(!err);
+          assert.ifError(err);
 
           assert(profiles[0].user);
           assert(profiles[1].user);
@@ -72,7 +72,7 @@ describe('Association Interface', function() {
         .populate('profile')
         .sort('quantity asc')
         .exec(function(err, users) {
-          assert(!err);
+          assert.ifError(err);
 
           assert(users[0].profile);
           assert(users[1].profile);
@@ -91,7 +91,7 @@ describe('Association Interface', function() {
           Associations.User_resource.find({ name: 'foobar' })
           .populate('profile')
           .exec(function(err, users) {
-            assert(!err);
+            assert.ifError(err);
             assert(users[0].name);
             assert(!users[0].profile, 'Expected `users[0].profile` to be falsy, but instead users[0] looks like ==> '+require('util').inspect(users[0], false, null));
             done();
@@ -105,7 +105,7 @@ describe('Association Interface', function() {
           Associations.User_resource.find({ name: 'foobar2' })
           .populate('profile')
           .exec(function(err, users) {
-            assert(!err);
+            assert.ifError(err);
             assert(users[0].name);
             assert(!users[0].profile, 'Expected `users[0].profile` to be falsy, but instead users[0] looks like ==> '+require('util').inspect(users[0], false, null));
             done();

--- a/interfaces/migratable/definition.test.js
+++ b/interfaces/migratable/definition.test.js
@@ -16,7 +16,7 @@ describe('Migratable Interface', function() {
 
       it('should cause new schema to have a createdAt attribute', function(done) {
         Migratable.User.describe(function (err, user) {
-          assert(!err);
+          assert.ifError(err);
           assert(user.createdAt);
           done();
         });
@@ -35,7 +35,7 @@ describe('Migratable Interface', function() {
 
       it('should cause new schema to have an updatedAt attribute', function(done) {
         Migratable.User.describe(function (err, user) {
-          assert(!err);
+          assert.ifError(err);
           assert(user.updatedAt);
           done();
         });
@@ -54,7 +54,7 @@ describe('Migratable Interface', function() {
 
       it('should cause new schema to have an id attribute', function(done) {
         Migratable.User.describe(function (err, user) {
-          assert(!err);
+          assert.ifError(err);
           assert(user.id);
           done();
         });

--- a/interfaces/migratable/migrate.drop.test.js
+++ b/interfaces/migratable/migrate.drop.test.js
@@ -15,7 +15,7 @@ describe('Migratable Interface', function() {
 
     it('should have tables', function(done) {
       Migratable.Drop.describe(function(err, schema) {
-        assert(!err);
+        assert.ifError(err);
         assert(schema);
         done();
       });
@@ -34,7 +34,7 @@ describe('Migratable Interface', function() {
             var ontology = obj.ontology;
 
             ontology.collections.drop.find().exec(function(err, pirates) {
-              assert(!err);
+              assert.ifError(err);
               assert.deepEqual(pirates, []);
               done();
             });

--- a/interfaces/migratable/migrate.safe.test.js
+++ b/interfaces/migratable/migrate.safe.test.js
@@ -15,7 +15,7 @@ describe('Migratable Interface', function() {
 
     it('should have NOT have tables', function(done) {
       Migratable.Safe.describe(function(err, schema) {
-        assert(!err);
+        assert.ifError(err);
         assert(!schema);
         done();
       });

--- a/interfaces/migratable/schema.test.js
+++ b/interfaces/migratable/schema.test.js
@@ -101,7 +101,7 @@ describe('Migratable Interface', function() {
 
       it('should return an error if unique constraint fails', function(done) {
         Migratable.Document.create({ title: 'uniqueConstraint 1', serialNumber: 'test' }, function(err, record) {
-          assert(!err);
+          assert.ifError(err);
           assert.equal(record.serialNumber, 'test');
 
           Migratable.Document.create({ title: 'uniqueConstraint 2', serialNumber: 'test' }, function(err, record) {

--- a/interfaces/queryable/findLike.test.js
+++ b/interfaces/queryable/findLike.test.js
@@ -20,7 +20,7 @@ describe('Queryable Interface', function() {
         if (err) return done(err);
 
         Queryable.User.findLike({ first_name: part }, function(err, users) {
-          assert(!err);
+          assert.ifError(err);
           assert(Array.isArray(users));
           assert.strictEqual(users.length, 2, util.format('expected 2 users, but got %s, see?\n%s', users.length, util.inspect(users, false, null) ));
           assert((users[0].first_name === testName && users[1].first_name === testName2) ||

--- a/interfaces/queryable/findOneLike.test.js
+++ b/interfaces/queryable/findOneLike.test.js
@@ -17,7 +17,7 @@ describe('Queryable Interface', function() {
         if (err) return done(err);
 
         Queryable.User.findOneLike({ first_name: part }, function(err, user) {
-          assert(!err);
+          assert.ifError(err);
           assert.equal(user.first_name, testName);
           done();
         });

--- a/interfaces/queryable/modifiers/contains.modifier.test.js
+++ b/interfaces/queryable/modifiers/contains.modifier.test.js
@@ -19,7 +19,7 @@ describe('Queryable Interface', function() {
             if(err) return done(err);
 
             Queryable.User.contains({ first_name: part }, function(err, users) {
-              assert(!err);
+              assert.ifError(err);
               assert(Array.isArray(users));
               assert.equal(users.length, 1);
               assert.equal(users[0].first_name, testName);
@@ -43,7 +43,7 @@ describe('Queryable Interface', function() {
             if(err) return done(err);
 
             Queryable.User.where({ first_name: { contains: part }}, function(err, users) {
-              assert(!err);
+              assert.ifError(err);
               assert(Array.isArray(users));
               assert.equal(users.length, 1);
               assert.equal(users[0].first_name, testName);

--- a/interfaces/queryable/modifiers/endsWith.modifier.test.js
+++ b/interfaces/queryable/modifiers/endsWith.modifier.test.js
@@ -19,7 +19,7 @@ describe('Queryable Interface', function() {
             if(err) return done(err);
 
             Queryable.User.endsWith({ first_name: part }, function(err, users) {
-              assert(!err);
+              assert.ifError(err);
               assert(Array.isArray(users));
               assert.equal(users.length, 1);
               assert.equal(users[0].first_name, testName);
@@ -43,7 +43,7 @@ describe('Queryable Interface', function() {
             if(err) return done(err);
 
             Queryable.User.where({ first_name: { endsWith: part }}, function(err, users) {
-              assert(!err);
+              assert.ifError(err);
               assert(Array.isArray(users));
               assert.equal(users.length, 1);
               assert.equal(users[0].first_name, testName);

--- a/interfaces/queryable/modifiers/greaterThan.modifier.test.js
+++ b/interfaces/queryable/modifiers/greaterThan.modifier.test.js
@@ -32,7 +32,7 @@ describe('Queryable Interface', function() {
 
         it('should return records with greaterThan key', function(done) {
           Queryable.User.find({ first_name: testName, age: { greaterThan: 40 }}).sort('age').exec(function(err, users) {
-            assert(!err);
+            assert.ifError(err);
             assert(Array.isArray(users));
             assert.strictEqual(users.length, 3);
             assert.strictEqual(users[0].age, 41);
@@ -42,7 +42,7 @@ describe('Queryable Interface', function() {
 
         it('should return records with symbolic usage > usage', function(done) {
           Queryable.User.find({ first_name: testName, age: { '>': 40 }}).sort('age').exec(function(err, users) {
-            assert(!err);
+            assert.ifError(err);
             assert(Array.isArray(users));
             assert.strictEqual(users.length, 3);
             assert.strictEqual(users[0].age, 41);
@@ -87,7 +87,7 @@ describe('Queryable Interface', function() {
 
         it('should return records with greaterThan key when searching dates', function(done) {
           Queryable.User.find({ type: testName, dob: { greaterThan: new Date(2013, 10, 9) }}).sort('first_name').exec(function(err, users) {
-            assert(!err);
+            assert.ifError(err);
             assert(Array.isArray(users));
             assert.strictEqual(users.length, 1);
             assert.equal(users[0].first_name, 'greaterThan_dates_user9');
@@ -97,7 +97,7 @@ describe('Queryable Interface', function() {
 
         it('should return records with symbolic usage > usage when searching dates', function(done) {
           Queryable.User.find({ type: testName, dob: { '>': new Date(2013, 10, 9) }}).sort('first_name').exec(function(err, users) {
-            assert(!err);
+            assert.ifError(err);
             assert(Array.isArray(users));
             assert.strictEqual(users.length, 1);
             assert.equal(users[0].first_name, 'greaterThan_dates_user9');
@@ -140,7 +140,7 @@ describe('Queryable Interface', function() {
 
         it('should return records with greaterThan key when searching strings', function(done) {
           Queryable.User.find({ type: testName, first_name: { greaterThan: '2 greaterThan_strings_user' }}).sort('first_name').exec(function(err, users) {
-            assert(!err);
+            assert.ifError(err);
             assert(Array.isArray(users));
             assert.strictEqual(users.length, 7);
             assert.equal(users[0].first_name, '3 greaterThan_strings_user');
@@ -150,7 +150,7 @@ describe('Queryable Interface', function() {
 
         it('should return records with symbolic usage > usage when searching strings', function(done) {
           Queryable.User.find({ type: testName, first_name: { '>': '2 greaterThan_strings_user' }}).sort('first_name').exec(function(err, users) {
-            assert(!err);
+            assert.ifError(err);
             assert(Array.isArray(users));
             assert.strictEqual(users.length, 7);
             assert.equal(users[0].first_name, '3 greaterThan_strings_user');
@@ -190,7 +190,7 @@ describe('Queryable Interface', function() {
 
         it('should return records with greaterThanOrEqual key', function(done) {
           Queryable.User.find({ first_name: testName, age: { greaterThanOrEqual: 41 }}).sort('age').exec(function(err, users) {
-            assert(!err);
+            assert.ifError(err);
             assert(Array.isArray(users));
             assert.strictEqual(users.length, 3);
             assert.strictEqual(users[0].age, 41);
@@ -200,7 +200,7 @@ describe('Queryable Interface', function() {
 
         it('should return records with symbolic usage >= usage', function(done) {
           Queryable.User.find({ first_name: testName, age: { '>=': 41 }}).sort('age').exec(function(err, users) {
-            assert(!err);
+            assert.ifError(err);
             assert(Array.isArray(users));
             assert.strictEqual(users.length, 3);
             assert.strictEqual(users[0].age, 41);
@@ -245,7 +245,7 @@ describe('Queryable Interface', function() {
 
         it('should return records with greaterThanOrEqual key when searching dates', function(done) {
           Queryable.User.find({ type: testName, dob: { greaterThanOrEqual: new Date(2013, 10, 9) }}).sort('first_name').exec(function(err, users) {
-            assert(!err);
+            assert.ifError(err);
             assert(Array.isArray(users));
             assert.strictEqual(users.length, 2);
             assert.equal(users[0].first_name, 'greaterThanOrEqual_dates_user8');
@@ -255,7 +255,7 @@ describe('Queryable Interface', function() {
 
         it('should return records with symbolic usage >= usage when searching dates', function(done) {
           Queryable.User.find({ type: testName, dob: { '>=': new Date(2013, 10, 9) }}).sort('first_name').exec(function(err, users) {
-            assert(!err);
+            assert.ifError(err);
             assert(Array.isArray(users));
             assert.strictEqual(users.length, 2);
             assert.equal(users[0].first_name, 'greaterThanOrEqual_dates_user8');
@@ -298,7 +298,7 @@ describe('Queryable Interface', function() {
 
         it('should return records with greaterThanOrEqual key when searching strings', function(done) {
           Queryable.User.find({ type: testName, first_name: { greaterThanOrEqual: '2 greaterThanOrEqual_strings_user' }}).sort('first_name').exec(function(err, users) {
-            assert(!err);
+            assert.ifError(err);
             assert(Array.isArray(users));
             assert.strictEqual(users.length, 8);
             assert.equal(users[0].first_name, '2 greaterThanOrEqual_strings_user');
@@ -308,7 +308,7 @@ describe('Queryable Interface', function() {
 
         it('should return records with symbolic usage >= usage when searching strings', function(done) {
           Queryable.User.find({ type: testName, first_name: { '>=': '2 greaterThanOrEqual_strings_user' }}).sort('first_name').exec(function(err, users) {
-            assert(!err);
+            assert.ifError(err);
             assert(Array.isArray(users));
             assert.strictEqual(users.length, 8);
             assert.equal(users[0].first_name, '2 greaterThanOrEqual_strings_user');

--- a/interfaces/queryable/modifiers/groupBy.modifier.test.js
+++ b/interfaces/queryable/modifiers/groupBy.modifier.test.js
@@ -36,7 +36,7 @@ describe('Queryable Interface', function() {
 
     it('should group by keys and sum values', function(done) {
       Queryable.User.find({ groupBy: ['type'], sum: ['age'] }, function(err, grouped) {
-        assert(!err);
+        assert.ifError(err);
         var asserted = false;
 
         asserted = grouped.filter(function(result){
@@ -57,7 +57,7 @@ describe('Queryable Interface', function() {
 
     it('should group by multiple keys and sum values', function(done) {
       Queryable.User.find({ groupBy: ['type', 'age'], sum: ['percent'] }, function(err, grouped) {
-        assert(!err);
+        assert.ifError(err);
 
         var asserted = grouped.filter(function(result){
           if(result.type === 'groupBy test' && result.age === 1) {
@@ -76,7 +76,7 @@ describe('Queryable Interface', function() {
 
     it('should group by keys and both sum and average values', function(done) {
       Queryable.User.find({ groupBy: ['type'], sum: ['age'], average: ['percent'] }, function(err, grouped) {
-        assert(!err);
+        assert.ifError(err);
         var asserted = grouped.filter(function(result){
           if(result.type === 'groupBy test') {
             assert.strictEqual(result.age, 45);
@@ -95,7 +95,7 @@ describe('Queryable Interface', function() {
 
     it('should allow match query with groupBy', function(done){
       Queryable.User.find({where: { age: { '>': 5 } }, groupBy: ['type'], sum: ['age'], average: ['percent'] }, function(err, grouped) {
-        assert(!err);
+        assert.ifError(err);
         var asserted = grouped.filter(function(result){
           if(result.type === 'groupBy test') {
             assert.strictEqual(result.age, 30);

--- a/interfaces/queryable/modifiers/in.modifier.test.js
+++ b/interfaces/queryable/modifiers/in.modifier.test.js
@@ -40,7 +40,7 @@ describe('Queryable Interface', function() {
 
       it('should return correct user', function(done) {
         Queryable.User.find({ first_name: ["foo", testName, "bar", "baz"] }, function(err, users) {
-          assert(!err);
+          assert.ifError(err);
           assert.equal(users.length, 1);
           assert.equal(users[0].first_name, testName);
           done();

--- a/interfaces/queryable/modifiers/lessThan.modifier.test.js
+++ b/interfaces/queryable/modifiers/lessThan.modifier.test.js
@@ -36,7 +36,7 @@ describe('Queryable Interface', function() {
           Queryable.User.find({ first_name: testName, age: { lessThan: 42 }})
           .sort('age asc')
           .exec(function(err, users) {
-            assert(!err);
+            assert.ifError(err);
             assert(Array.isArray(users));
             assert.strictEqual(users.length, 2);
             assert.strictEqual(users[0].age, 40);
@@ -48,7 +48,7 @@ describe('Queryable Interface', function() {
           Queryable.User.find({ first_name: testName, age: { '<': 42 }})
           .sort('age asc')
           .exec(function(err, users) {
-            assert(!err);
+            assert.ifError(err);
             assert(Array.isArray(users));
             assert.strictEqual(users.length, 2);
             assert.strictEqual(users[0].age, 40);
@@ -93,7 +93,7 @@ describe('Queryable Interface', function() {
 
         it('should return records with lessThan key when searching dates', function(done) {
           Queryable.User.find({ type: testName, dob: { lessThan: new Date(2013, 10, 2) }}).sort('first_name').exec(function(err, users) {
-            assert(!err);
+            assert.ifError(err);
             assert(Array.isArray(users));
             assert.strictEqual(users.length, 1);
             assert.equal(users[0].first_name, 'lessThan_dates_user0');
@@ -103,7 +103,7 @@ describe('Queryable Interface', function() {
 
         it('should return records with symbolic usage < usage when searching dates', function(done) {
           Queryable.User.find({ type: testName, dob: { '<': new Date(2013, 10, 2) }}).sort('first_name').exec(function(err, users) {
-            assert(!err);
+            assert.ifError(err);
             assert(Array.isArray(users));
             assert.strictEqual(users.length, 1);
             assert.equal(users[0].first_name, 'lessThan_dates_user0');
@@ -143,7 +143,7 @@ describe('Queryable Interface', function() {
 
         it('should return records with lessThanOrEqual key', function(done) {
           Queryable.User.find({ first_name: testName, age: { lessThanOrEqual: 42 }}).sort('age').exec(function(err, users) {
-            assert(!err);
+            assert.ifError(err);
             assert(Array.isArray(users));
             assert.strictEqual(users.length, 3);
             assert.strictEqual(users[0].age, 40);
@@ -153,7 +153,7 @@ describe('Queryable Interface', function() {
 
         it('should return records with symbolic usage <= usage', function(done) {
           Queryable.User.find({ first_name: testName, age: { '<=': 42 }}).sort('age').exec(function(err, users) {
-            assert(!err);
+            assert.ifError(err);
             assert(Array.isArray(users));
             assert.strictEqual(users.length, 3);
             assert.strictEqual(users[0].age, 40);
@@ -198,7 +198,7 @@ describe('Queryable Interface', function() {
 
         it('should return records with lessThanOrEqual key when searching dates', function(done) {
           Queryable.User.find({ type: testName, dob: { lessThanOrEqual: new Date(2013, 10, 2) }}).sort('first_name').exec(function(err, users) {
-            assert(!err);
+            assert.ifError(err);
             assert(Array.isArray(users));
             assert.strictEqual(users.length, 2);
             assert.equal(users[1].first_name, 'lessThanOrEqual_dates_user1');
@@ -208,7 +208,7 @@ describe('Queryable Interface', function() {
 
         it('should return records with symbolic usage <= usage when searching dates', function(done) {
           Queryable.User.find({ type: testName, dob: { '<=': new Date(2013, 10, 2) }}).sort('first_name').exec(function(err, users) {
-            assert(!err);
+            assert.ifError(err);
             assert(Array.isArray(users));
             assert.strictEqual(users.length, 2);
             assert.equal(users[1].first_name, 'lessThanOrEqual_dates_user1');

--- a/interfaces/queryable/modifiers/like.modifier.test.js
+++ b/interfaces/queryable/modifiers/like.modifier.test.js
@@ -19,7 +19,7 @@ describe('Queryable Interface', function() {
           if(err) return done(err);
 
           Queryable.User.find({ like: { first_name: part } }, function(err, users) {
-            assert(!err);
+            assert.ifError(err);
             assert(Array.isArray(users));
             assert.equal(users.length, 1);
             assert.equal(users[0].first_name, testName);
@@ -36,7 +36,7 @@ describe('Queryable Interface', function() {
           if(err) return done(err);
 
           Queryable.User.find({ like: { first_name: '%'+part+'%' } }, function(err, users) {
-            assert(!err);
+            assert.ifError(err);
             assert(Array.isArray(users));
             assert.equal(users.length, 1);
             assert.equal(users[0].first_name, testName);

--- a/interfaces/queryable/modifiers/limit.modifier.test.js
+++ b/interfaces/queryable/modifiers/limit.modifier.test.js
@@ -30,7 +30,7 @@ describe('Queryable Interface', function() {
 
     it('should return the correct amount of records', function(done) {
       Queryable.User.find({ where: { type: 'limit test' }, limit: 3 }, function(err, users) {
-        assert(!err);
+        assert.ifError(err);
         assert(Array.isArray(users));
         assert.strictEqual(users.length, 3);
         done();
@@ -39,7 +39,7 @@ describe('Queryable Interface', function() {
 
     it('as an option should return correct amount of records', function(done) {
       Queryable.User.find({ where: { type: 'limit test' } }, { limit: 3 }, function(err, users) {
-        assert(!err);
+        assert.ifError(err);
         assert(Array.isArray(users));
         assert.strictEqual(users.length, 3);
         done();

--- a/interfaces/queryable/modifiers/max.modifier.test.js
+++ b/interfaces/queryable/modifiers/max.modifier.test.js
@@ -36,7 +36,7 @@ describe('Queryable Interface', function() {
 
     it('should get the maximum of the key', function(done) {
       Queryable.User.find({where:{type: 'max test'}, max: ['age'] }, function(err, summed) {
-        assert(!err);
+        assert.ifError(err);
         assert.strictEqual(summed[0].age, 9010);
         done();
       });
@@ -44,7 +44,7 @@ describe('Queryable Interface', function() {
 
     it('should max multiple keys', function(done) {
       Queryable.User.find({where:{type: 'max test'}, max: ['age', 'percent'] }, function(err, summed) {
-        assert(!err);
+        assert.ifError(err);
         assert.strictEqual(summed[0].age, 9010);
         assert.strictEqual(summed[0].percent, 9005.5);
         done();
@@ -57,7 +57,7 @@ describe('Queryable Interface', function() {
         max: ['age'],
         average: ['percent']
       }, function(err, summed) {
-        assert(!err);
+        assert.ifError(err);
         assert.strictEqual(summed[0].age, 9010);
         assert.strictEqual(summed[0].percent, 9003.25);
         done();

--- a/interfaces/queryable/modifiers/min.modifier.test.js
+++ b/interfaces/queryable/modifiers/min.modifier.test.js
@@ -36,7 +36,7 @@ describe('Queryable Interface', function() {
 
     it('should get the minimum of the key', function(done) {
       Queryable.User.find({ where:{type: 'min test'}, min: ['age'] }, function(err, summed) {
-        assert(!err);
+        assert.ifError(err);
         assert.strictEqual(summed[0].age, -9);
         done();
       });
@@ -44,7 +44,7 @@ describe('Queryable Interface', function() {
 
     it('should min multiple keys', function(done) {
       Queryable.User.find({ where:{type: 'min test'}, min: ['age', 'percent'] }, function(err, summed) {
-        assert(!err);
+        assert.ifError(err);
         assert.strictEqual(summed[0].age, -9);
         assert.strictEqual(summed[0].percent, -4.5);
         done();
@@ -57,7 +57,7 @@ describe('Queryable Interface', function() {
         min: ['age'],
         average: ['percent']
       }, function(err, summed) {
-        assert(!err);
+        assert.ifError(err);
         assert.strictEqual(summed[0].age, -9);
         assert.strictEqual(summed[0].percent, -2.25);
         done();

--- a/interfaces/queryable/modifiers/not.modifier.test.js
+++ b/interfaces/queryable/modifiers/not.modifier.test.js
@@ -34,7 +34,7 @@ describe('Queryable Interface', function() {
         Queryable.User.find({ first_name: testName, age: { not: 40 }})
         .sort('age asc')
         .exec(function(err, users) {
-          assert(!err);
+          assert.ifError(err);
           assert(Array.isArray(users));
           assert.strictEqual(users.length, 3);
           assert.strictEqual(users[0].age, 41);
@@ -52,7 +52,7 @@ describe('Queryable Interface', function() {
         Queryable.User.find({ first_name: testName, age: { '!': 40 }})
         .sort('age asc')
         .exec(function(err, users) {
-          assert(!err);
+          assert.ifError(err);
           assert(Array.isArray(users));
           assert.strictEqual(users.length, 3);
           assert.strictEqual(users[0].age, 41);
@@ -65,7 +65,7 @@ describe('Queryable Interface', function() {
         Queryable.User.find({ first_name: testName, email: { '!': '41@test.com' }})
         .sort('age asc')
         .exec(function(err, users) {
-          assert(!err);
+          assert.ifError(err);
 
           assert(Array.isArray(users));
           assert.strictEqual(users.length, 3);

--- a/interfaces/queryable/modifiers/notIn.modifier.test.js
+++ b/interfaces/queryable/modifiers/notIn.modifier.test.js
@@ -33,7 +33,7 @@ describe('Queryable Interface', function() {
 
       it('should return correct user', function(done) {
         Queryable.User.find({ first_name: { '!': ["foo", testName, "bar", "baz"] }}, function(err, users) {
-          assert(!err);
+          assert.ifError(err);
           assert.strictEqual(users.length, 1);
           assert.equal(users[0].first_name, 'something else');
           done();

--- a/interfaces/queryable/modifiers/select.modifier.test.js
+++ b/interfaces/queryable/modifiers/select.modifier.test.js
@@ -40,7 +40,7 @@ describe('Queryable Interface', function() {
 
     it('should return a record with a single field first_name', function(done) {
       Queryable.User.find({ where: { type: 'select test' }, select: ['first_name'], sort: 'age' }, function(err, users) {
-        assert(!err);
+        assert.ifError(err);
         var user = users[0];
         assert.equal(user.first_name, 'select_user');
         assertNotProperty(user, 'last_name');
@@ -55,7 +55,7 @@ describe('Queryable Interface', function() {
     
     it('should return multiples records with a single field first_name', function(done) {
       Queryable.User.find({ where: {}, select: ['first_name'], sort: 'age' }, function(err, users) {
-        assert(!err);
+        assert.ifError(err);
         assert(users.length > 1);
         for(var i=0; i<users.length; i++){
           var user = users[i];
@@ -73,7 +73,7 @@ describe('Queryable Interface', function() {
     
     it('should return a record with a single field first_name (findOne)', function(done) {
       Queryable.User.findOne({ where: { type: 'select test' }, select: ['first_name'] }, function(err, user) {
-        assert(!err);
+        assert.ifError(err);
         assert.equal(user.first_name, 'select_user');
         assertNotProperty(user, 'last_name');
         assertNotProperty(user, 'email');
@@ -87,7 +87,7 @@ describe('Queryable Interface', function() {
 
     it('should return a record with multiple fields', function(done) {
       Queryable.User.find({ where: { type: 'select test' }, select: ['first_name', 'age'], sort: 'age' }, function(err, users) {
-        assert(!err);
+        assert.ifError(err);
         var user = users[0];
         assert.equal(user.first_name, 'select_user');
         assertNotProperty(user, 'last_name');
@@ -102,7 +102,7 @@ describe('Queryable Interface', function() {
 
     it('in absence of SELECT modifier should return a record with all fields', function(done) {
       Queryable.User.find({ where: { type: 'select test' }, sort: 'age' }, function(err, users) {
-        assert(!err);
+        assert.ifError(err);
         var user = users[0];
         assert.equal(user.first_name, 'select_user');
         assert.equal(user.last_name, 'select_name_0');

--- a/interfaces/queryable/modifiers/skip.modifier.test.js
+++ b/interfaces/queryable/modifiers/skip.modifier.test.js
@@ -30,7 +30,7 @@ describe('Queryable Interface', function() {
 
     it('should return the correct amount of records', function(done) {
       Queryable.User.find({ where: { type: 'skip test' }, skip: 3 }, function(err, users) {
-        assert(!err);
+        assert.ifError(err);
         assert(Array.isArray(users));
         assert.strictEqual(users.length, 7);
         done();
@@ -39,7 +39,7 @@ describe('Queryable Interface', function() {
 
     it('as an option should return correct amount of records', function(done) {
       Queryable.User.find({ where: { type: 'skip test' } }, { skip: 3 }, function(err, users) {
-        assert(!err);
+        assert.ifError(err);
         assert(Array.isArray(users));
         assert.strictEqual(users.length, 7);
         done();

--- a/interfaces/queryable/modifiers/sort.modifier.test.js
+++ b/interfaces/queryable/modifiers/sort.modifier.test.js
@@ -38,7 +38,7 @@ describe('Queryable Interface', function() {
 
     it('should sort records using binary notation for asc', function(done) {
       Queryable.User.find({ where: { type: 'sort test' }, sort: { dob: 1 } }, function(err, users) {
-        assert(!err);
+        assert.ifError(err);
         assert.strictEqual(users.length, 10);
         assert.equal(users[0].first_name, 'sort_user0');
         done();
@@ -47,7 +47,7 @@ describe('Queryable Interface', function() {
 
     it('should sort records using binary notation desc', function(done) {
       Queryable.User.find({ where: { type: 'sort test' }, sort: { dob: 0 } }, function(err, users) {
-        assert(!err);
+        assert.ifError(err);
         assert.strictEqual(users.length, 10);
         assert.equal(users[0].first_name, 'sort_user9');
         done();
@@ -56,7 +56,7 @@ describe('Queryable Interface', function() {
 
     it('should sort records using string notation for asc', function(done) {
       Queryable.User.find({ where: { type: 'sort test' }, sort: 'dob asc' }, function(err, users) {
-        assert(!err);
+        assert.ifError(err);
         assert.strictEqual(users.length, 10);
         assert.equal(users[0].first_name, 'sort_user0');
         done();
@@ -65,7 +65,7 @@ describe('Queryable Interface', function() {
 
     it('should sort records using string notation for desc', function(done) {
       Queryable.User.find({ where: { type: 'sort test' }, sort: 'dob desc' }, function(err, users) {
-        assert(!err);
+        assert.ifError(err);
         assert.strictEqual(users.length, 10);
         assert.equal(users[0].first_name, 'sort_user9');
         done();
@@ -74,7 +74,7 @@ describe('Queryable Interface', function() {
 
     it('should sort when sort is an option', function(done) {
       Queryable.User.find({ where: { type: 'sort test' } }, { sort: { dob: 0 } }, function(err, users) {
-        assert(!err);
+        assert.ifError(err);
         assert.strictEqual(users.length, 10);
         assert.equal(users[0].first_name, 'sort_user9');
         done();
@@ -113,7 +113,7 @@ describe('Queryable Interface', function() {
 
     it('should sort records using multiple sort criteria, with first name desc', function(done) {
       Queryable.User.find({ where: { type: 'sort test multi' }, sort: { last_name: 1, first_name: 0 } }, function(err, users) {
-        assert(!err);
+        assert.ifError(err);
 
         // check the smith's are together and ordered by first_name
         assert.equal(users[0].first_name, 'bob');
@@ -128,7 +128,7 @@ describe('Queryable Interface', function() {
 
     it('should sort records using multiple sort criteria, with first name asc', function(done) {
       Queryable.User.find({ where: { type: 'sort test multi' }, sort: { last_name: 1, first_name: 1 } }, function(err, users) {
-        assert(!err);
+        assert.ifError(err);
 
         // check the smith's are together and ordered by first_name
         assert.equal(users[0].first_name, 'bob');

--- a/interfaces/queryable/modifiers/startsWith.modifier.test.js
+++ b/interfaces/queryable/modifiers/startsWith.modifier.test.js
@@ -20,7 +20,7 @@ describe('Queryable Interface', function() {
             if (err) return done(err);
 
             Queryable.User.startsWith({ first_name: part }, function(err, users) {
-              assert(!err);
+              assert.ifError(err);
               assert(Array.isArray(users));
               assert.equal(users.length, 1);
               assert.equal(users[0].first_name, testName);
@@ -44,7 +44,7 @@ describe('Queryable Interface', function() {
             if (err) return done(err);
 
             Queryable.User.where({ first_name: { startsWith: part }}, function(err, users) {
-              assert(!err);
+              assert.ifError(err);
               assert(Array.isArray(users));
               assert.equal(users.length, 1);
               assert.equal(users[0].first_name, testName);

--- a/interfaces/queryable/modifiers/sum.modifier.test.js
+++ b/interfaces/queryable/modifiers/sum.modifier.test.js
@@ -36,7 +36,7 @@ describe('Queryable Interface', function() {
 
     it('should sum by key and only return that key with the sum value', function(done) {
       Queryable.User.find({ where:{type: 'sum test'}, sum: ['age'] }, function(err, summed) {
-        assert(!err);
+        assert.ifError(err);
         assert.strictEqual(summed[0].age, 45);
         done();
       });
@@ -44,7 +44,7 @@ describe('Queryable Interface', function() {
 
     it('should sum by multiple keys and return sums of all keys', function(done) {
       Queryable.User.find({ where:{type: 'sum test'}, sum: ['age', 'percent'] }, function(err, summed) {
-        assert(!err);
+        assert.ifError(err);
         assert.strictEqual(summed[0].age, 45);
         assert.strictEqual(summed[0].percent, 22.5);
         done();
@@ -57,7 +57,7 @@ describe('Queryable Interface', function() {
         sum: ['age'],
         average: ['percent']
       }, function(err, summed) {
-        assert(!err);
+        assert.ifError(err);
         assert.strictEqual(summed[0].age, 45);
         assert.strictEqual(summed[0].percent, 2.25);
         done();

--- a/interfaces/scalable/crud.test.js
+++ b/interfaces/scalable/crud.test.js
@@ -60,7 +60,7 @@ describe('Load Testing', function() {
 
         User.create(data, next);
       }, function(err, users) {
-        assert(!err);
+        assert.ifError(err);
         assert.strictEqual(users.length, CONNECTIONS);
         done();
       });

--- a/interfaces/semantic/create.test.js
+++ b/interfaces/semantic/create.test.js
@@ -12,7 +12,7 @@ describe('Semantic Interface', function() {
     it('should create a new record', function(done) {
       Semantic.User.create({ first_name: 'Foo' }, function(err, record) {
         if (err) { console.error(err); }
-        assert(!err);
+        assert.ifError(err);
         assert.equal(record.first_name, 'Foo');
         done();
       });
@@ -21,7 +21,7 @@ describe('Semantic Interface', function() {
     it('should return a generated PK', function(done) {
       Semantic.User.create({ first_name: 'FooBar' }, function(err, user) {
         if (err) { console.error(err); }
-        assert(!err);
+        assert.ifError(err);
         assert.equal(user.first_name, 'FooBar');
         assert(user.id);
         done();
@@ -31,7 +31,7 @@ describe('Semantic Interface', function() {
     it('should return generated timestamps', function(done) {
       Semantic.User.create({ first_name: 'Foo', last_name: 'Bar' }, function(err, user) {
         if (err) { console.error(err); }
-        assert(!err);
+        assert.ifError(err);
         assert.equal(toString.call(user.createdAt), '[object Date]');
         assert.equal(toString.call(user.updatedAt), '[object Date]');
         done();
@@ -41,7 +41,7 @@ describe('Semantic Interface', function() {
     it('should return a model instance', function(done) {
       Semantic.User.create({ first_name: 'Foo', last_name: 'Bar' }, function(err, user) {
         if (err) { console.error(err); }
-        assert(!err);
+        assert.ifError(err);
         assert.equal(user.fullName(), 'Foo Bar');
         done();
       });
@@ -49,7 +49,7 @@ describe('Semantic Interface', function() {
 
     it('should normalize undefined values to null', function(done) {
       Semantic.User.create({ first_name: 'Yezy', last_name: undefined }, function(err, user) {
-        assert(!err);
+        assert.ifError(err);
         assert.equal(user.last_name, null);
         done();
       });
@@ -63,7 +63,7 @@ describe('Semantic Interface', function() {
         users.push({ first_name: 'test_' + i, type: testName });
       }
       Semantic.User.create(users, function(err, users) {
-        assert(!err);
+        assert.ifError(err);
         users.forEach(function(val, idx){
           assert.equal(users[idx].first_name, 'test_' + idx);
         });
@@ -98,7 +98,7 @@ describe('Semantic Interface', function() {
       it('should have saved the proper values (with auto-increment values)', function(done) {
         Semantic.User.find({where : { type: testName }, sort : {first_name : 1}}, function(err, users) {
           if (err) return done(err);
-          assert(!err);
+          assert.ifError(err);
           assert.equal(users.length, 4, 'Expecting 4 "users", but actually got '+users.length+': '+require('util').inspect(users, false, null));
           assert.equal(users[0].first_name, 'test_0' );
           done();

--- a/interfaces/semantic/createEach.test.js
+++ b/interfaces/semantic/createEach.test.js
@@ -16,7 +16,7 @@ describe('Semantic Interface', function() {
       ];
 
       Semantic.User.createEach(usersArray, function(err, users) {
-        assert(!err);
+        assert.ifError(err);
         assert(Array.isArray(users));
         assert.strictEqual(users.length, 2);
         done();
@@ -25,7 +25,7 @@ describe('Semantic Interface', function() {
 
     it('should insert 2 records verififed by find', function(done) {
       Semantic.User.find({ type: 'createEach' }, function(err, users) {
-        assert(!err);
+        assert.ifError(err);
         assert.strictEqual(users.length, 2);
         done();
       });

--- a/interfaces/semantic/destroy.js
+++ b/interfaces/semantic/destroy.js
@@ -24,7 +24,7 @@ describe('Semantic Interface', function() {
 
       it('should destroy a record', function(done) {
         Semantic.User.destroy({ first_name: 'Destroy' }, function(err, records) {
-          assert(!err);
+          assert.ifError(err);
           assert(Array.isArray(records));
           assert.strictEqual(records.length, 1);
           assert.equal(records[0].first_name, 'Destroy');
@@ -65,7 +65,7 @@ describe('Semantic Interface', function() {
 
       it('should destroy a record', function(done) {
         Semantic.User.destroy(user.id, function(err, status) {
-          assert(!err);
+          assert.ifError(err);
           done();
         });
       });
@@ -98,7 +98,7 @@ describe('Semantic Interface', function() {
 
       it('should destroy all the records', function(done) {
         Semantic.User.destroy(function(err, users) {
-          assert(!err);
+          assert.ifError(err);
           done();
         });
       });
@@ -131,11 +131,11 @@ describe('Semantic Interface', function() {
 
       it.skip('should not destroy any records', function(done) {
         Semantic.User.destroy({ id: [] }, function(err, users) {
-          assert(!err);
+          assert.ifError(err);
           assert.strictEqual(users.length, 0);
 
           Semantic.User.find({ first_name: 'dummy_test_in' }, function(err, users) {
-            assert(!err);
+            assert.ifError(err);
             assert.strictEqual(users.length, 3);
             done();
           });

--- a/interfaces/semantic/find.test.js
+++ b/interfaces/semantic/find.test.js
@@ -30,7 +30,7 @@ describe('Semantic Interface', function() {
 
     it('should return 10 records', function(done) {
       Semantic.User.find({ type: 'find test' }, function(err, users) {
-        assert(!err);
+        assert.ifError(err);
         assert(Array.isArray(users));
         assert.strictEqual(users.length, 10);
         done();
@@ -39,7 +39,7 @@ describe('Semantic Interface', function() {
 
     it('should return 1 record when searching for a specific record (integer test) with find', function(done) {
       Semantic.User.find({ age: 10 }, function(err, users) {
-        assert(!err);
+        assert.ifError(err);
         assert(Array.isArray(users));
         assert.strictEqual(users.length, 1);
         done();
@@ -52,7 +52,7 @@ describe('Semantic Interface', function() {
           lessThanOrEqual: 49 // should return half the records - from 0 to 40
         }
       }, function(err, users) {
-        assert(!err);
+        assert.ifError(err);
         assert(Array.isArray(users));
         assert.equal(users.length, 5);
         done();
@@ -72,7 +72,7 @@ describe('Semantic Interface', function() {
 
     it('should work with no criteria passed in', function(done) {
       Semantic.User.find(function(err, users) {
-        assert(!err);
+        assert.ifError(err);
         assert(Array.isArray(users));
         done();
       });

--- a/interfaces/semantic/findOne.test.js
+++ b/interfaces/semantic/findOne.test.js
@@ -24,7 +24,7 @@ describe('Semantic Interface', function() {
 
     it('should return a single record', function(done) {
       Semantic.User.findOne({ first_name: 'findOne test' }, function(err, user) {
-        assert(!err);
+        assert.ifError(err);
         assert.equal(user.first_name, 'findOne test');
         done();
       });
@@ -42,7 +42,7 @@ describe('Semantic Interface', function() {
 
     it('should return null if a record is not found', function(done) {
       Semantic.User.findOne({ first_name: 'findOne blah' }, function(err, user) {
-        assert(!err);
+        assert.ifError(err);
         assert(!user);
         done();
       });
@@ -50,7 +50,7 @@ describe('Semantic Interface', function() {
 
     it('should work with just an id passed in', function(done) {
       Semantic.User.findOne(id, function(err, user) {
-        assert(!err);
+        assert.ifError(err);
         assert.equal(user.first_name, 'findOne test');
         done();
       });

--- a/interfaces/semantic/types/array.type.js
+++ b/interfaces/semantic/types/array.type.js
@@ -12,11 +12,11 @@ describe('Semantic Interface', function() {
 
       it('should store proper array value', function(done) {
         Semantic.User.create({ list: [0,1,2,3] }, function(err, createdRecord) {
-          assert(!err);
+          assert.ifError(err);
           assert(Array.isArray(createdRecord.list));
           assert.strictEqual(createdRecord.list.length, 4);
           Semantic.User.findOne({id: createdRecord.id}, function (err, record) {
-            assert(!err);
+            assert.ifError(err);
             assert(Array.isArray(record.list));
             assert.strictEqual(record.list.length, 4);
             done();

--- a/interfaces/semantic/types/binary.type.js
+++ b/interfaces/semantic/types/binary.type.js
@@ -24,7 +24,7 @@ describe('Semantic Interface', function() {
           assert(!err, err);
           assert.equal(new Buffer(createdRecord.avatar).toString('utf-8'), str);
           Semantic.User.findOne({id: createdRecord.id}, function (err, record) {
-              assert(!err);
+              assert.ifError(err);
               // read out the stored binary thing
               var outbuf = new Buffer(record.avatar);
               assert.equal(outbuf.toString('utf-8'), str);

--- a/interfaces/semantic/types/boolean.type.js
+++ b/interfaces/semantic/types/boolean.type.js
@@ -12,10 +12,10 @@ describe('Semantic Interface', function() {
 
       it('should store proper boolean value', function(done) {
         Semantic.User.create({ status: true }, function (err, createdRecord) {
-          assert(!err);
+          assert.ifError(err);
           assert.strictEqual(createdRecord.status, true);
           Semantic.User.findOne({id: createdRecord.id}, function (err, record) {
-            assert(!err);
+            assert.ifError(err);
             assert.strictEqual(record.status, true);
             done();
           });

--- a/interfaces/semantic/types/date.type.js
+++ b/interfaces/semantic/types/date.type.js
@@ -14,11 +14,11 @@ describe('Semantic Interface', function() {
         var date = new Date();
         var origDate = Date.parse(date);
         Semantic.User.create({ dob: date }, function(err, createdRecord) {
-          assert(!err);
+          assert.ifError(err);
           var createdDate = Date.parse(new Date(createdRecord.dob));
           assert.strictEqual(origDate, createdDate);
           Semantic.User.findOne({id: createdRecord.id}, function (err, record) {
-            assert(!err);
+            assert.ifError(err);
             // Convert both dates to unix timestamps
             var resultDate = Date.parse(new Date(record.dob));
             assert.strictEqual(origDate, resultDate);

--- a/interfaces/semantic/types/float.type.js
+++ b/interfaces/semantic/types/float.type.js
@@ -12,10 +12,10 @@ describe('Semantic Interface', function() {
 
       it('should store proper float value', function(done) {
         Semantic.User.create({ percent: 0.001 }, function(err, createdRecord) {
-          assert(!err);
+          assert.ifError(err);
           assert.strictEqual(createdRecord.percent, 0.001);
           Semantic.User.findOne({id: createdRecord.id}, function(err, record) {
-            assert(!err);
+            assert.ifError(err);
             assert.strictEqual(record.percent, 0.001);
             done();
           });

--- a/interfaces/semantic/types/integer.type.js
+++ b/interfaces/semantic/types/integer.type.js
@@ -12,10 +12,10 @@ describe('Semantic Interface', function() {
 
       it('should store proper integer', function(done) {
         Semantic.User.create({ age: 27 }, function (err, createdRecord) {
-          assert(!err);
+          assert.ifError(err);
           assert.strictEqual(createdRecord.age, 27);
           Semantic.User.findOne({id: createdRecord.id}, function (err, record) {
-            assert(!err);
+            assert.ifError(err);
             assert.strictEqual(record.age, 27);
             done();
           });

--- a/interfaces/semantic/types/json.type.js
+++ b/interfaces/semantic/types/json.type.js
@@ -12,11 +12,11 @@ describe('Semantic Interface', function() {
 
       it('should store proper object value', function(done) {
         Semantic.User.create({ obj: {foo: 'bar'} }, function(err, createdRecord) {
-          assert(!err);
+          assert.ifError(err);
           assert.strictEqual(createdRecord.obj, Object(createdRecord.obj));
           assert.equal(createdRecord.obj.foo, 'bar');
           Semantic.User.findOne({id: createdRecord.id}, function (err, record) {
-            assert(!err);
+            assert.ifError(err);
             assert.strictEqual(record.obj, Object(record.obj));
             assert.equal(record.obj.foo, 'bar');
             done();

--- a/interfaces/semantic/types/string.type.js
+++ b/interfaces/semantic/types/string.type.js
@@ -12,10 +12,10 @@ describe('Semantic Interface', function() {
 
       it('should store proper string value', function(done) {
         Semantic.User.create({ first_name: 'Foo' }, function(err, createdRecord) {
-          assert(!err);
+          assert.ifError(err);
           assert.equal(createdRecord.first_name, 'Foo');
           Semantic.User.findOne({id: createdRecord.id}, function (err, record) {
-            assert(!err);
+            assert.ifError(err);
             assert.equal(record.first_name, 'Foo');
             done();
           });

--- a/interfaces/semantic/update.test.js
+++ b/interfaces/semantic/update.test.js
@@ -54,7 +54,7 @@ describe('Semantic Interface', function() {
 
       it('should update model attributes', function(done) {
         Semantic.User.update({ type: 'update' }, { last_name: 'updated' }, function(err, users) {
-          assert(!err);
+          assert.ifError(err);
           assert(Array.isArray(users));
           assert.strictEqual(users.length, 10);
           assert.equal(users[0].last_name, 'updated');
@@ -64,7 +64,7 @@ describe('Semantic Interface', function() {
 
       it('should return model instances', function(done) {
        Semantic. User.update({ type: 'update' }, { last_name: 'updated again' }).exec(function(err, users) {
-          assert(!err);
+          assert.ifError(err);
           assert(users[0].id);
           assert.strictEqual(users[0].first_name.indexOf('update_user'), 0);
           assert.equal(users[0].last_name, 'updated again');
@@ -76,7 +76,7 @@ describe('Semantic Interface', function() {
 
       it('should work with just an ID passed in', function(done) {
         Semantic.User.update(id, { first_name: 'foo' }).sort('first_name').exec(function(err, users) {
-          assert(!err);
+          assert.ifError(err);
           assert.equal(users[0].first_name, 'foo');
           done();
         });
@@ -84,7 +84,7 @@ describe('Semantic Interface', function() {
 
       it('should work with an empty object', function(done) {
         Semantic.User.update({}, { type: 'update all' }, function(err, users) {
-          assert(!err);
+          assert.ifError(err);
           assert.strictEqual(users.length, 10);
           assert.equal(users[0].type, 'update all');
           done();
@@ -93,7 +93,7 @@ describe('Semantic Interface', function() {
 
       it('should work with null values', function(done) {
         Semantic.User.update(id, { age: null }, function(err, users) {
-          assert(!err);
+          assert.ifError(err);
           assert.strictEqual(users[0].age, null);
           done();
         });
@@ -101,7 +101,7 @@ describe('Semantic Interface', function() {
       
       it('should update model attributes without supplying required fields', function(done) {
         Semantic.Thing.update(thingId, { description: 'An updated thing' }, function(err, things) {
-          assert(!err);
+          assert.ifError(err);
           assert(Array.isArray(things));
           assert.strictEqual(things.length, 1);
           assert.equal(things[0].id, thingId);
@@ -144,7 +144,7 @@ describe('Semantic Interface', function() {
 
       it('should allow the record to be found', function(done) {
         Semantic.User.find({ type: 'updateFind' }, function(err, users) {
-          assert(!err);
+          assert.ifError(err);
           assert.strictEqual(users.length, 2);
           assert.equal(users[0].last_name, 'Updated Find');
           assert.equal(users[1].last_name, 'Updated Find');

--- a/interfaces/sql/query.test.js
+++ b/interfaces/sql/query.test.js
@@ -30,7 +30,7 @@ describe('SQL Interface', function() {
 
     it('should return non undefined result', function(done) {
       Sql.User.query('SELECT * FROM usertablesql', undefined, function(err, users) {
-        assert(!err);
+        assert.ifError(err);
         assert(users);
         done();
       });


### PR DESCRIPTION
If an error is present, `assert(!err)` reports that false was expected to be
true, which means you have to re-run the test and print the error to actually
figure out what the error was. `assert.ifError(err)` fails if the error is
defined and will print the error if one is present, which means you don't have
to re-run the tests to figure out what went wrong.
