### PR TITLE
Point deps at latest release candidate

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "bluebird": "2.9.34",
     "lodash": "3.10.1",
     "mocha": "2.3.4",
-    "pg": "git://github.com/Shyp/node-postgres#timeout",
-    "sails-postgresql": "git+https://github.com/Shyp/sails-postgresql.git#v1.2.0",
+    "pg": "4.3.0",
+    "sails-postgresql": "git+https://github.com/Shyp/sails-postgresql.git#v1.4.0",
     "should": "8",
-    "waterline": "git+https://github.com/Shyp/waterline.git#v3.1.0"
+    "waterline": "git+https://github.com/Shyp/waterline.git#v3.2.0"
   },
   "devDependencies": {
     "jpath": "^0.0.20",


### PR DESCRIPTION
This reverts the timeout logic in sails-postgresql v1.2.0 and pulls in
Waterline 3.2.0 with support for better error messages and cloned create()s.
