### PR TITLE
Upgrade sails-postgresql to v1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lodash": "3.10.1",
     "mocha": "2.3.4",
     "pg": "4.3.0",
-    "sails-postgresql": "git+https://github.com/Shyp/sails-postgresql.git#v1.4.0",
+    "sails-postgresql": "git+https://github.com/Shyp/sails-postgresql.git#v1.5.0",
     "should": "8",
     "waterline": "git+https://github.com/Shyp/waterline.git#v3.2.0"
   },


### PR DESCRIPTION
Pulls in the latest change for E_UNIQUE failures, which I don't think we
specifically test for anywhere in here.
