### PR TITLE
Upgrade sails-postgresql to v1.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "mocha": "2.3.4",
     "pg": "4.3.0",
     "pg-native": "1.10.0",
-    "sails-postgresql": "git+https://github.com/Shyp/sails-postgresql.git#v1.8.0",
+    "sails-postgresql": "git+https://github.com/Shyp/sails-postgresql.git#v1.8.2",
     "should": "8",
     "waterline": "git+https://github.com/Shyp/waterline.git#v3.2.0"
   },


### PR DESCRIPTION
This change uses `pg-native` instead of `pg` for queries.
