### PR TITLE
Point sails-postgresql at an official release

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "mocha": "2.3.4",
     "pg": "4.3.0",
     "pg-native": "1.10.0",
-    "sails-postgresql": "git+https://github.com/Shyp/sails-postgresql.git#waterline-sequel-update",
+    "sails-postgresql": "git+https://github.com/Shyp/sails-postgresql.git#v1.9.0",
     "should": "8",
     "waterline": "git+https://github.com/Shyp/waterline.git#v3.2.0"
   },


### PR DESCRIPTION
Needed to point at a branch because these two libraries depend on each other.
