### PR TITLE
Remove pg-native

### DIFF
--- a/interfaces/associations/support/bootstrap.js
+++ b/interfaces/associations/support/bootstrap.js
@@ -8,7 +8,7 @@ var Waterline = require('waterline');
 
 var _ = require('lodash');
 var async = require('async');
-var pg = require('pg').native;
+var pg = require('pg');
 
 // Require Fixtures
 var fixtures = {

--- a/interfaces/migratable/support/bootstrap.js
+++ b/interfaces/migratable/support/bootstrap.js
@@ -5,7 +5,7 @@ var fs = require('fs');
 var path = require('path');
 
 var async = require('async');
-var pg = require('pg').native;
+var pg = require('pg');
 
 var bootstrapFn = require('./bootstrapFn');
 

--- a/interfaces/queryable/support/bootstrap.js
+++ b/interfaces/queryable/support/bootstrap.js
@@ -7,7 +7,7 @@ var path = require('path');
 
 var _ = require('lodash');
 var async = require('async');
-var pg = require('pg').native;
+var pg = require('pg');
 
 var Waterline = require('waterline');
 

--- a/interfaces/semantic/support/bootstrap.js
+++ b/interfaces/semantic/support/bootstrap.js
@@ -8,7 +8,7 @@ var path = require('path');
 
 var _ = require('lodash');
 var async = require('async');
-var pg = require('pg').native;
+var pg = require('pg');
 
 var Waterline = require('waterline');
 

--- a/interfaces/sql/support/bootstrap.js
+++ b/interfaces/sql/support/bootstrap.js
@@ -7,7 +7,7 @@ var path = require('path');
 
 var _ = require('lodash');
 var async = require('async');
-var pg = require('pg').native;
+var pg = require('pg');
 
 var Waterline = require('waterline');
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "lodash": "3.10.1",
     "mocha": "2.3.4",
     "pg": "4.3.0",
-    "pg-native": "1.10.0",
     "sails-postgresql": "git+https://github.com/Shyp/sails-postgresql.git#v1.9.0",
     "should": "8",
     "waterline": "git+https://github.com/Shyp/waterline.git#v3.2.0"


### PR DESCRIPTION
There are a lot of incompatibilities. We need to add better tests around errors
here, fortunately at least the Shyp API tests break when the error format
changes.
