### PR TITLE
Upgrade node-postgres to v4.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "bluebird": "2.9.34",
     "lodash": "3.10.1",
     "mocha": "2.3.4",
-    "pg": "4.3.0",
+    "pg": "git+https://github.com/Shyp/node-postgres.git#v4.6.0",
     "sails-postgresql": "git+https://github.com/Shyp/sails-postgresql.git#v1.9.0",
     "should": "8",
     "waterline": "git+https://github.com/Shyp/waterline.git#v3.2.0"


### PR DESCRIPTION
This version lets us timeout resource acquisition - if the timeout hits before
a connection becomes available, let's hit the callback with an error.

Diff: https://github.com/shyp/node-postgres/compare/v4.3.0...v4.6.0
